### PR TITLE
use correct shell for building packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Clone without CRLF
 ```
 git config --global core.autocrlf false
 ```
-Using **"C:\devkitPro\msys2\mingw64.exe"**
+Using **"C:\devkitPro\msys2\msys2.exe"**
 ```
 pacman -S patch
 pacman -S binutils


### PR DESCRIPTION
Using the mingw64 shell will cause weird issues building packages. We need to use msys2 packages which understand msys2 paths.